### PR TITLE
fix converting string zipcode to gmt offset

### DIFF
--- a/lib/area/string.rb
+++ b/lib/area/string.rb
@@ -49,7 +49,8 @@ class String
 
   def to_gmt_offset
     Area::ZIP_CODES.each do |row|
-      @offset = row[5] if row[2] != nil and row[2].upcase == self.to_s.upcase
+      @offset = row[5] if row[2] != nil and
+                          (row[2].upcase == self.to_s.upcase or row[0] == self.to_s)
     end
     @offset || nil
   end

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -20,8 +20,12 @@ class TestInteger < MiniTest::Unit::TestCase
     assert_equal "-73.95427", 11211.to_lon
   end
 
-  def test_that_it_converts_zip_code_to_gmt_offset
+  def test_that_it_converts_zip_code_int_to_gmt_offset
     assert_equal "-5", 11211.to_gmt_offset
+  end
+
+  def test_that_it_converts_zip_code_string_to_gmt_offset
+    assert_equal "-5", "11211".to_gmt_offset
   end
 
   def test_that_it_handles_bad_area_codes


### PR DESCRIPTION
Previously it was not considering zipcode column from the csv file during the to gmt conversion.
