### PR TITLE
[feature] adding multiple option support to String#to_region

### DIFF
--- a/lib/area/string.rb
+++ b/lib/area/string.rb
@@ -23,7 +23,13 @@ class String
   #   #=> NY
   #
   #   "11211".to_region
-  #   #=> "Brooklyn, NY",
+  #   #=> "Brooklyn, NY"
+  #
+  #   "11211".to_region(:city => true)
+  #   #=> "Brooklyn"
+  #
+  #   "11211".to_region(:city => true, :state => true)
+  #   #=> ["Brooklyn", "NY"]
   #
   # Returns a String of converted area codes or zipcodes.
   def to_region(options = {})
@@ -33,20 +39,20 @@ class String
     elsif self.to_s.length == 5
       if row = Area.zip_codes.find {|row| row.first == self.to_s }
         if row.first == self.to_s
-          if options[:city]
-            return row[1]
-          elsif options[:state]
-            return row[2]
+          result = []
+          if !options.keys.empty?
+            result << row[1] if options[:city]
+            result << row[2] if options[:state]
           else
-            return row[1] + ', ' + row[2]
+            result << row[1] + ', ' + row[2]
           end
+          return (result.size > 1) ? result : result.first
         end
       end
     else
       raise ArgumentError, "You must provide a valid area or zip code", caller
     end
   end
-
 
   # Public: Convert a place to a zip code.
   #

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -68,6 +68,10 @@ class TestString < MiniTest::Unit::TestCase
     assert_equal "NY", "11211".to_region(:state => true)
   end
 
+  def test_that_it_supports_multiple_options_for_zipcodes
+    assert_equal ["Brooklyn", "NY"], "11211".to_region(:city => true, :state => true)
+  end
+
   def test_that_it_converts_to_area_code
     assert_equal ["907"], "AK".to_area
     assert_equal ["203", "860"], "CT".to_area


### PR DESCRIPTION
@jgv thanks for providing this great gem!

I had a need to pull city and state separately from a zip code and I didn't want to do any string splitting or multiple searches. So, I added support for handling multiple options when calling `String#to_region` and I thought it might be useful to everyone. 

This change keeps the existing API intact with no changes, but will now return an array of results if you pass multiple options.

``` ruby
"11211".to_region #=> "Brooklyn, NY"
"11211".to_region(:city => true) #=> "Brooklyn"
"11211".to_region(:city => true, :state => true) #=> ["Brooklyn", "NY"]
```
